### PR TITLE
Add test to verify blog post links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,17 @@ To use this site as a template for your own academic website:
 6. **Deploy via GitHub Pages**:
    - Go to your repository’s **Settings** > **Pages**
    - Under "Source", choose the `main` branch (or the default branch)
-   - Your website will be published at:  
+   - Your website will be published at:
      `https://<your-github-username>.github.io/`
+
+## Running Tests
+
+To run the automated checks that verify blog post links, execute:
+
+```bash
+python3 -m unittest
+```
+
 
 ## License
 

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -1,0 +1,20 @@
+import re
+import unittest
+from pathlib import Path
+
+class TestBlogPostLinks(unittest.TestCase):
+    def setUp(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        posts_js = repo_root / 'blog' / 'posts.js'
+        with posts_js.open() as f:
+            self.content = f.read()
+        self.hrefs = re.findall(r'href:\s*"([^"]+)"', self.content)
+
+    def test_html_files_exist(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        for href in self.hrefs:
+            path = repo_root / href
+            self.assertTrue(path.exists(), f"Missing file: {href}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unittest that checks blog post hrefs in blog/posts.js
- document running tests in README

## Testing
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68406a35a3cc833297386a93ba7a20ce